### PR TITLE
Added redhat support, and adjusted paramater names to be more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ include 'dropbear'
 ```
   class {
     'dropbear':
-      ssh_port        => '443',
-      ssh_args        => '-s',
-      banner          => 'Powered by dropbear',
+      port            => '443',
+      extra_args      => '-s',
+      banner          => '/etc/banner',
   }
 ```
 
 ## Other class parameters
 * no\_start: boolean, 0 for start dropbear, and 1 for stop (init), (default: 0, start)
-* ssh\_port: integer, ssh TCP port listens on (default: 22)
-* ssh\_args: string, dropbear ssh args (refs: man dropbear)
+* port: integer, ssh TCP port listens on (default: 22)
+* extra\_args: string, dropbear ssh args (refs: man dropbear)
 * banner: string, banner file containing a message to be sent to clients before they connect
 * rsakey: string, RSA hostkey file (default: /etc/dropbear/dropbear\_rsa\_host\_key)
 * dsskey: string, DSS hostkey file (default: /etc/dropbear/dropbear\_dss\_host\_key)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,11 +15,13 @@ class dropbear (
   $package_name   = $dropbear::params::package_name,
   $service_name   = $dropbear::params::service_name,
   $no_start       = '0',
-  $ssh_port       = '22',
-  $ssh_args       = '',
+  $port           = '22',
+  $extra_args     = '',
   $banner         = '',
   $rsakey         = $dropbear::params::rsakey,
   $dsskey         = $dropbear::params::dsskey,
+  $cfg_file       = $dropbear::params::cfg_file,
+  $cfg_template   = $dropbear::params::cfg_template,
   $receive_window = '65536'
 ) inherits dropbear::params {
 
@@ -37,12 +39,12 @@ class dropbear (
   }
 
   file {
-    '/etc/default/dropbear':
+    $cfg_file:
       ensure  => file,
-      content => template('dropbear/dropbear.erb'),
+      content => template($cfg_template),
       owner   => root,
       group   => root,
-      mode    => '0644',
+      mode    => '0444',
       notify  => Service[$service_name],
       require => Package[$package_name];
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,16 @@ class dropbear::params {
       $service_name   = 'dropbear'
       $rsakey         = '/etc/dropbear/dropbear_rsa_host_key'
       $dsskey         = '/etc/dropbear/dropbear_dss_host_key'
+      $cfg_file       = '/etc/default/dropbear'
+      $cfg_template   = 'dropbear/debian.erb'
+    }
+    'RedHat': {
+      $package_name   = 'dropbear'
+      $service_name   = 'dropbear'
+      $rsakey         = '/etc/dropbear/dropbear_rsa_host_key'
+      $dsskey         = '/etc/dropbear/dropbear_dss_host_key'
+      $cfg_file       = '/etc/sysconfig/dropbear'
+      $cfg_template   = 'dropbear/redhat.erb'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")

--- a/spec/classes/dropbear_spec.rb
+++ b/spec/classes/dropbear_spec.rb
@@ -11,17 +11,49 @@ describe 'dropbear', :type => :class do
     end
   end
 
-  context "On Debian" do
+  describe "On Debian" do
     let(:facts) {{ :osfamily => 'Debian' }}
     it { should include_class("dropbear::params") }
     it { should contain_package('dropbear') }
+    it { should contain_service('dropbear') }
+    it { should contain_file('/etc/default/dropbear/').with(
+        :owner => 'root',
+        :group => 'root',
+        :mode  => '0444'
+      )
+    }
+    context "When an alternate port is given" do
+      let(:params) {{ :port => '42' }}
+      it { should contain_file('/etc/default/dropbear/').with_content(/DROPBEAR_PORT=42/) }
+    end
+    context "When a banner is specified" do
+      let(:params) {{ :banner => '/etc/test_banner' }}
+      it { should contain_file('/etc/default/dropbear/').with_content(/DROPBEAR_BANNER="\/etc\/test_banner"/) }
+    end
   end
 
-  #TODO
-  #context "On RedHat" do
-  #  let(:facts) {{ :osfamily => 'RedHat' }}
-  #  it { should include_class("dropbear::params") }
-  #  it { should contain_package('dropbear') }
-  #end
+  describe "On RedHat" do
+    let(:facts) {{ :osfamily => 'RedHat' }}
+    it { should include_class("dropbear::params") }
+    it { should contain_package('dropbear') }
+    it { should contain_service('dropbear') }
+    it { should contain_file('/etc/sysconfig/dropbear/').with(
+        :owner => 'root',
+        :group => 'root',
+        :mode  => '0444'
+      )
+    }
+    context "When an alternate port is given" do
+      let(:params) {{ :port => '42' }}
+      it { should contain_file('/etc/sysconfig/dropbear/').with_content(/-p 42/) }
+    end
+    context "When a banner is specified" do
+      let(:params) {{ :banner => '/etc/test_banner' }}
+      it { should contain_file('/etc/sysconfig/dropbear/').with_content(/ -b \/etc\/test_banner /) }
+    end
+    context "When a banner is NOT specified" do
+      it { should_not contain_file('/etc/sysconfig/dropbear/').with_content(/ -b /) }
+    end
+  end
 end
 

--- a/templates/debian.erb
+++ b/templates/debian.erb
@@ -1,16 +1,16 @@
 # MANAGED BY PUPPET
 # Module:: dropbear
-# File:: template/dropbear.erb
+# File:: template/debian.erb
 #
 # disabled because OpenSSH is installed
 # change to NO_START=0 to enable Dropbear
 NO_START=<%= @no_start %>
 
 # the TCP port that Dropbear listens on
-DROPBEAR_PORT=<%= @ssh_port %>
+DROPBEAR_PORT=<%= @port %>
 
 # any additional arguments for Dropbear
-DROPBEAR_EXTRA_ARGS="<%= @ssh_args %>"
+DROPBEAR_EXTRA_ARGS="<%= @extra_args %>"
 
 # specify an optional banner file containing a message to be
 # sent to clients before they connect, such as "/etc/issue.net"

--- a/templates/redhat.erb
+++ b/templates/redhat.erb
@@ -1,0 +1,5 @@
+# MANAGED BY PUPPET
+# Module:: dropbear
+# File:: template/redhat.erb
+#
+OPTIONS="-p <%= @port %><% if @banner != '' -%> -b <%= @banner -%><% end -%> -r <%= @rsakey %> -d <%= @dsskey %> -W <%= @receive_window %> <%= @extra_args %>"


### PR DESCRIPTION
Can I disable "master-only" tests?

Are you ok with me changing the parameter names? Seems ok as they are already namespaced inside the "dropbear" module. 
