### PR TITLE
adds Fedora 28 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,12 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "28"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description
Adds back in Fedora support.  I tested with Fedora 28.  package is included in default,  params info matches osfamily RedHat defaults, etc.

#### This Pull Request (PR) fixes the following issues
fixes #11 
